### PR TITLE
do.sh: Use built-in venv instead of virtualenv.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -88,8 +88,8 @@ function generate() {
 function install_deps_local_rpm() {
     echo "-- Installing local dependencies"
     yum install redhat-lsb-core datamash \
-        python3-pip python3-virtualenv python3-netaddr python3 python3-devel \
-        python-virtualenv podman podman-docker \
+        python3-pip python3-netaddr python3 python3-devel \
+        podman podman-docker \
         --skip-broken -y
     [ -e /usr/bin/pip ] || ln -sf /usr/bin/pip3 /usr/bin/pip
 
@@ -98,7 +98,7 @@ function install_deps_local_rpm() {
 function install_deps_local_deb() {
     echo "-- Installing local dependencies"
     apt -y install datamash podman podman-docker python3-pip \
-           python3-virtualenv python3-netaddr python3 python3-all-dev
+           python3-netaddr python3 python3-all-dev
 }
 
 function install_deps_remote() {
@@ -133,7 +133,7 @@ function install_venv() {
     pushd ${rundir}
     if [ ! -f ${ovn_heater_venv}/bin/activate ]; then
         rm -rf ${ovn_heater_venv}
-        python3 -m virtualenv ${ovn_heater_venv}
+        python3 -m venv ${ovn_heater_venv}
     fi
     source ${ovn_heater_venv}/bin/activate
     if is_rpm_based; then

--- a/ovn-fake-multinode-utils/playbooks/install-dependencies.yml
+++ b/ovn-fake-multinode-utils/playbooks/install-dependencies.yml
@@ -7,7 +7,6 @@
           - git
           - gcc
           - python3-pyyaml
-          - python3-virtualenv
           - python3-devel
           - containers-common
         state: present
@@ -31,7 +30,6 @@
           - gcc
           - openvswitch-switch
           - python3-yaml
-          - python3-virtualenv
           - python3-all-dev
         state: present
       when: ansible_os_family == "Debian"


### PR DESCRIPTION
The functionality of built-in venv is enough for our use case.
Also, virtualenv is not available in some distributions (rhel9).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
