### PR TITLE
ext_cmd: Silence background commands.

### DIFF
--- a/ovn-tester/ovn_ext_cmd.py
+++ b/ovn-tester/ovn_ext_cmd.py
@@ -52,7 +52,7 @@ class ExtCmdUnit(object):
             cmd += f' {self.pid_opt} {stdout.getvalue().strip()}'
 
         if self.background_opt:
-            cmd += ' &'
+            cmd += ' >/dev/null 2>&1 &'
 
         stdout = StringIO()
         node.run(cmd, stdout=stdout)

--- a/test-scenarios/ovn-low-scale.yml
+++ b/test-scenarios/ovn-low-scale.yml
@@ -13,7 +13,7 @@ ext_cmd:
   - c0:
     iteration: 1
     node: "ovn-scale-*"
-    cmd: "perf record -a -g -F 99 -o perf.data"
+    cmd: "perf record -a -g -q -F 99 -o perf.data"
     pid_name: "ovn-controller"
     pid_opt: "-p"
     background_opt: True
@@ -27,7 +27,7 @@ ext_cmd:
   - c2:
     iteration: 1
     node: "ovn-central*"
-    cmd: "perf record -a -g -F 99 -o perf.data"
+    cmd: "perf record -a -g -q -F 99 -o perf.data"
     pid_name: "ovn-northd"
     pid_opt: "-p"
     background_opt: True


### PR DESCRIPTION
We're using a common interactive shell for command execution. Background commands may print something at unpredictable times messing up output from other commands and causing random failures.

Silence all background commands by default.  Also adding a --quiet option to perf invocations while at it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
