### PR TITLE
ovn-tester: Fix exceptions while adding LBs after leadership transfer.

### DIFF
--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -669,22 +669,22 @@ class OvnNbctl:
     def lb_add_to_routers(self, lb, routers):
         with self.idl.transaction(check_error=True) as txn:
             for r in routers:
-                txn.add(self.idl.lr_lb_add(r, lb.uuid))
+                txn.add(self.idl.lr_lb_add(r, lb.uuid, may_exist=True))
 
     def lb_add_to_switches(self, lb, switches):
         with self.idl.transaction(check_error=True) as txn:
             for s in switches:
-                txn.add(self.idl.ls_lb_add(s, lb.uuid))
+                txn.add(self.idl.ls_lb_add(s, lb.uuid, may_exist=True))
 
     def lb_remove_from_routers(self, lb, routers):
         with self.idl.transaction(check_error=True) as txn:
             for r in routers:
-                txn.add(self.idl.lr_lb_del(r, lb.uuid))
+                txn.add(self.idl.lr_lb_del(r, lb.uuid, if_exists=True))
 
     def lb_remove_from_switches(self, lb, switches):
         with self.idl.transaction(check_error=True) as txn:
             for s in switches:
-                txn.add(self.idl.ls_lb_del(s, lb.uuid))
+                txn.add(self.idl.ls_lb_del(s, lb.uuid, if_exists=True))
 
     def sync(self, wait="hv", timeout=DEFAULT_CTL_TIMEOUT):
         with self.idl.transaction(


### PR DESCRIPTION
Python IDL reconnects on leadership transfer before receiving reply for an in-progress transaction.  But the transaction might, and likely will, actually succeed.  So the LB may already exist after re-connection. Let ovsdbapp know about that, so it doesn't throw exceptions when this happens.

This doesn't solve all the possible issues with other types of resources, but LBs are the most common after ports that already have a proper handling in place.

Closes: https://github.com/ovn-org/ovn-heater/issues/146