### PR TITLE
ci: Bump Ubuntu to 23.03 and ensure pip is installed.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ low_scale_task:
       - image_project: fedora-cloud
         image: family/fedora-cloud-38
       - image_project: ubuntu-os-cloud
-        image: family/ubuntu-2210-amd64
+        image: family/ubuntu-2304-amd64
     platform: linux
     memory: 8G
     disk: 40

--- a/do.sh
+++ b/do.sh
@@ -108,16 +108,14 @@ function generate() {
 function install_deps_local_rpm() {
     echo "-- Installing local dependencies"
     yum install redhat-lsb-core datamash \
-        python3-pip python3-netaddr python3 python3-devel \
+        python3-netaddr python3 python3-devel \
         podman \
         --skip-broken -y
-    [ -e /usr/bin/pip ] || ln -sf /usr/bin/pip3 /usr/bin/pip
-
 }
 
 function install_deps_local_deb() {
     echo "-- Installing local dependencies"
-    apt -y install datamash podman python3-pip \
+    apt -y install datamash podman \
            python3-netaddr python3 python3-all-dev python3-venv
 }
 
@@ -134,9 +132,7 @@ function install_venv() {
         python3 -m venv ${ovn_heater_venv}
     fi
     source ${ovn_heater_venv}/bin/activate
-    if is_rpm_based; then
-        python3 -m ensurepip
-    fi
+    python3 -m ensurepip --upgrade
     python3 -m pip install -r ${topdir}/utils/requirements.txt
     deactivate
     popd


### PR DESCRIPTION
22.10 is EOL and not usable in Cirrus CI anymore.  Also, ensure pip is installed in the venv on deb-based platforms too.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
