### PR TITLE
NBCTL: Fix missing `execute()` when adding ACLs

### DIFF
--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -585,9 +585,13 @@ class OvnNbctl:
         verdict="allow",
     ):
         if entity == "switch":
-            self.idl.acl_add(name, direction, priority, match, verdict)
+            self.idl.acl_add(
+                name, direction, priority, match, verdict
+            ).execute()
         else:  # "port-group"
-            self.idl.pg_acl_add(name, direction, priority, match, verdict)
+            self.idl.pg_acl_add(
+                name, direction, priority, match, verdict
+            ).execute()
 
     def route_add(self, router, network, gw, policy="dst-ip"):
         if network.n4 and gw.ip4:


### PR DESCRIPTION
Missing `execute()` calls in `OvnNbctl.acl_add()` method resulted in ACLs never getting created in OVN Northbound database.

Testing/Verification:

 * Run ocp-20-np-multitenant test scenario which utilises ACLs
 * Log into OVN ovn-central container on OVN-CENTRAL host
 * Dump ACL table
   * `ovsdb-client dump unix:/var/run/ovn/ovnnb_db.sock OVN_Northbound ACL`

Before this change the table would be empty during and after the test scenario.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
