### PR TITLE
treewide: Remove useless object inheritance.

### DIFF
--- a/ovn-tester/ovn_context.py
+++ b/ovn-tester/ovn_context.py
@@ -10,7 +10,7 @@ active_context = None
 ITERATION_STAT_NAME = 'Iteration Total'
 
 
-class Context(object):
+class Context:
     def __init__(
         self,
         cluster,

--- a/ovn-tester/ovn_ext_cmd.py
+++ b/ovn-tester/ovn_ext_cmd.py
@@ -13,7 +13,7 @@ class CentralNodeWrapper(Sandbox):
         )
 
 
-class ExtCmdUnit(object):
+class ExtCmdUnit:
     def __init__(self, conf, central_node, worker_nodes):
         self.iteration = conf.get('iteration')
         self.cmd = conf.get('cmd')
@@ -59,7 +59,7 @@ class ExtCmdUnit(object):
         return stdout.getvalue().strip()
 
 
-class ExtCmd(object):
+class ExtCmd:
     def __init__(self, config, central_node, worker_nodes):
         self.cmd_map = defaultdict(list)
         for ext_cmd in config.get('ext_cmd', list()):

--- a/ovn-tester/ovn_load_balancer.py
+++ b/ovn-tester/ovn_load_balancer.py
@@ -11,7 +11,7 @@ class InvalidProtocol(Exception):
         return f"Invalid Protocol: {self.args}"
 
 
-class OvnLoadBalancer(object):
+class OvnLoadBalancer:
     def __init__(self, lb_name, nbctl, vips=None, protocols=VALID_PROTOCOLS):
         '''
         Create load balancers with optional vips.
@@ -114,7 +114,7 @@ class OvnLoadBalancer(object):
             }
 
 
-class OvnLoadBalancerGroup(object):
+class OvnLoadBalancerGroup:
     def __init__(self, group_name, nbctl):
         self.nbctl = nbctl
         self.name = group_name

--- a/ovn-tester/ovn_sandbox.py
+++ b/ovn-tester/ovn_sandbox.py
@@ -50,7 +50,7 @@ class SSH:
                 log.info(out)
 
 
-class PhysicalNode(object):
+class PhysicalNode:
     def __init__(self, hostname, log_cmds):
         self.ssh = SSH(hostname, log_cmds)
 
@@ -58,7 +58,7 @@ class PhysicalNode(object):
         self.ssh.run(cmd=cmd, stdout=stdout, raise_on_error=raise_on_error)
 
 
-class Sandbox(object):
+class Sandbox:
     def __init__(self, phys_node, container):
         self.phys_node = phys_node
         self.container = container

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -456,7 +456,7 @@ DEFAULT_VIP_PORT = 80
 DEFAULT_BACKEND_PORT = 8080
 
 
-class Namespace(object):
+class Namespace:
     def __init__(self, cluster, name, global_cfg):
         self.cluster = cluster
         self.nbctl = cluster.nbctl
@@ -747,7 +747,7 @@ class Namespace(object):
             self.load_balancer.add_vips(vips)
 
 
-class Cluster(object):
+class Cluster:
     def __init__(self, central_node, worker_nodes, cluster_cfg, brex_cfg):
         # In clustered mode use the first node for provisioning.
         self.central_node = central_node


### PR DESCRIPTION
We expect Python3 to be used and in Python3 all classes inherit from object.

Reported-at: https://github.com/ovn-org/ovn-heater/pull/173#discussion_r1325922500

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
