### PR TITLE
do.sh: Add `refresh-tester` subcommand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,19 @@ cd ~/ovn-heater
 RPM_SELINUX=$rpm_url_openvswitch-selinux-extra-policy RPM_OVS=$rpm_url_openvswitch RPM_OVN_COMMON=$rpm_url_ovn RPM_OVN_HOST=$rpm_url_ovn-host RPM_OVN_CENTRAL=$rpm_url_ovn-central ./do.sh install
 ```
 
+## Update Tester code
+
+To update code in Tester container run:
+
+```
+cd ~/ovn-heater
+./do.sh refresh-tester
+```
+
+This is handy if you are just making changes to the code inside `ovn-tester`
+package, and you don't need to rebuild `OVN`/`OVS` packages or
+`fake-multinode` image.
+
 ## Regenerate the ansible inventory:
 
 If the physical topology has changed then update

--- a/do.sh
+++ b/do.sh
@@ -316,6 +316,15 @@ function install() {
     popd
 }
 
+function refresh_tester() {
+    pushd ${rundir}
+
+    install_ovn_tester
+    pull_ovn_tester
+
+    popd
+}
+
 function translate_yaml() {
     local test_file=$1
 
@@ -492,7 +501,7 @@ function run_test() {
 }
 
 function usage() {
-    die "Usage: $0 install|generate|init|run <scenario> <out-dir>"
+    die "Usage: $0 install|generate|init|refresh-tester|run <scenario> <out-dir>"
 }
 
 do_lockfile=/tmp/do.sh.lock
@@ -508,6 +517,8 @@ case "${1:-"usage"}" in
     "generate")
         ;&
     "init")
+        ;&
+    "refresh-tester")
         ;&
     "run")
         take_lock $0
@@ -540,6 +551,9 @@ case "${1:-"usage"}" in
     "init")
         init_ovn_fake_multinode
         pull_ovn_fake_multinode
+        ;;
+    "refresh-tester")
+        refresh_tester
         ;;
     "run")
         cmd=$0


### PR DESCRIPTION
`refresh-tester` subcommand of `do.sh` triggers only rebuild of a tester container. It provides a faster way to apply/test your changes if you work only inside the `ovn-tester` package, and you don't want to rebuild OVN packages or fake-multinode image.

---
This is just something that I found handy in my workflow.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
