### PR TITLE
bringup-cluster: Compute central facts for all types of nodes.

### DIFF
--- a/ovn-fake-multinode-utils/playbooks/bringup-cluster.yml
+++ b/ovn-fake-multinode-utils/playbooks/bringup-cluster.yml
@@ -17,8 +17,8 @@
       chdir: "{{ ovn_fake_multinode_target_path }}/ovn-fake-multinode"
 
 
-- name: Bring up central nodes
-  hosts: central_hosts
+- name: Compute central facts
+  hosts: central_hosts, worker_hosts
   tasks:
   - name: Compute central facts (standalone)
     when: clustered_db == "no"
@@ -30,6 +30,10 @@
     ansible.builtin.set_fact:
       n_ips: '{{ n_relays|int + 3 }}'
 
+
+- name: Bring up central nodes
+  hosts: central_hosts
+  tasks:
   - name: Start central containers
     environment:
       CENTRAL_COUNT: '{{ n_az }}'


### PR DESCRIPTION
We accidentally only computed them for central_hosts but we actually need them on workers too.

Fixes: 29e078134421 ("ovn-tester: add the capability to run multiple independent clusters")

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
