### PR TITLE
do.sh: Add ability to run ovn-heater on Ubuntu

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,7 +60,12 @@ low_scale_task:
 
   install_script:
     - 'sed -i "s/<host>/$(hostname)/g" ${PHYS_DEPLOYMENT}'
-    - ./do.sh install
+    # test with ubuntu-based ovn-fake-multinode if test runs on Ubuntu image
+    - 'if [ $(which apt) ]; then
+        export OS_BASE=ubuntu;
+        export OS_IMAGE_OVERRIDE=ubuntu:rolling;
+       fi;
+       ./do.sh install'
 
   pack_caches_script:
     - rm -rf runtime-cache/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,8 @@ COPY $SSH_KEY /root/.ssh/
 
 COPY ovn-fake-multinode-utils/process-monitor.py /tmp/
 
+# This variable is needed on systems where global python's
+# environment is marked as "Externally managed" (PEP 668) to allow pip
+# installation of "global" packages.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN pip3 install -r /ovn-tester/requirements.txt

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ cd ~/ovn-heater
 OVS_REPO=https://github.com/dceara/ovs OVS_BRANCH=tmp-branch OVN_REPO=https://github.com/dceara/ovn OVN_BRANCH=tmp-branch-2 ./do.sh install
 ```
 
+To override base image of ovn-fake-multinode, which is by default
+`fedora:latest`, you can use following environment variables:
+- OS_BASE
+- OS_IMAGE_OVERRIDE
+
+For example, to use latest Ubuntu image you can run:
+
+```
+cd ~/ovn-heater
+OS_BASE=ubuntu OS_IMAGE_OVERRIDE=ubuntu:rolling ./do.sh install
+```
 NOTE: Because the installation step is responsible for deploying the ovn-tester
 container to the TESTER, this means that if any changes are made to the
 ovn-tester application, the installation step must be re-run.

--- a/README.md
+++ b/README.md
@@ -191,9 +191,6 @@ For example, to use latest Ubuntu image you can run:
 cd ~/ovn-heater
 OS_BASE=ubuntu OS_IMAGE_OVERRIDE=ubuntu:rolling ./do.sh install
 ```
-NOTE: Because the installation step is responsible for deploying the ovn-tester
-container to the TESTER, this means that if any changes are made to the
-ovn-tester application, the installation step must be re-run.
 
 ## Perform a reinstallation (e.g., new OVS/OVN versions are needed):
 

--- a/do.sh
+++ b/do.sh
@@ -185,6 +185,7 @@ ovn_branch="${OVN_BRANCH:-main}"
 ovn_fmn_repo="${OVN_FAKE_MULTINODE_REPO:-https://github.com/ovn-org/ovn-fake-multinode.git}"
 ovn_fmn_branch="${OVN_FAKE_MULTINODE_BRANCH:-main}"
 
+OS_BASE="${OS_BASE:-fedora}"
 OS_IMAGE_OVERRIDE="${OS_IMAGE_OVERRIDE}"
 OS_IMAGE_DEFAULT="registry.fedoraproject.org/fedora:latest"
 
@@ -250,7 +251,7 @@ function install_ovn_fake_multinode() {
         fi
 
         # Build images locally.
-        OS_IMAGE=$os_image OVS_SRC_PATH=${rundir}/ovs OVN_SRC_PATH=${rundir}/ovn \
+        OS_IMAGE=$os_image OS_BASE=${OS_BASE} OVS_SRC_PATH=${rundir}/ovs OVN_SRC_PATH=${rundir}/ovn \
             EXTRA_OPTIMIZE=${EXTRA_OPTIMIZE} USE_OVSDB_ETCD=${USE_OVSDB_ETCD} \
             RUNC_CMD=podman ./ovn_cluster.sh build
     fi


### PR DESCRIPTION
Please review commit-by-commit.

This is a follow-up change after ovn-fake-multinode added support for ubuntu-baed builds (https://github.com/ovn-org/ovn-fake-multinode/pull/85)
