### PR TITLE
playbooks/dependencies: Update package cache on deb systems.

### DIFF
--- a/ovn-fake-multinode-utils/playbooks/install-dependencies.yml
+++ b/ovn-fake-multinode-utils/playbooks/install-dependencies.yml
@@ -24,13 +24,14 @@
       when: ansible_os_family == "RedHat"
 
     - name: Install required packages
-      ansible.builtin.package:
+      ansible.builtin.apt:
         name:
           - git
           - gcc
           - openvswitch-switch
           - python3-yaml
           - python3-all-dev
+        update_cache: true
         state: present
       when: ansible_os_family == "Debian"
 


### PR DESCRIPTION
If the package cache is not updated for example after a clean install, the `install-dependencies` playbook may fail with errors like this:

    TASK [Install container command] ***************************
    {"changed": false, "msg": "No package matching 'podman' is available"}

Use the `apt` build in ansible module and set `update_cache` to 'true' to fix this issue.