### PR TITLE
do.sh: Fix bloating of the resource usage report for central nodes.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -401,8 +401,10 @@ function mine_data() {
     grep died ${logs} | sed 's/.*\/\(ovn-.*\)/\1/' > mined-data/crashes
     [ -s mined-data/crashes ] || rm -f mined-data/crashes
 
+    # Collecting stats for the tester and central components from the first
+    # 3 availability zones to avoid bloating the report.
     resource_usage_logs=$(find ${out_dir}/logs -name process-stats.json \
-                            | grep -v ovn-scale)
+                            | grep -E 'ovn-tester|ovn-central-az[0-2]-')
     python3 ${topdir}/utils/process-stats.py \
         resource-usage-report-central.html ${resource_usage_logs}
 


### PR DESCRIPTION
In case of a large number of availability zones the size of the resource usage report becomes unmanageable and browsers are not even able to open them.  For example, the size of the report on a 120 node cluster-density test is 166 MB.

Fix that the same way we do for workers - gather statistics only from the first 3 zones.

For the future we'll need to have aggregated stats in addition to these truncated ones, so we don't overlook potential issues and can compare cluster-wide resource usage with different number of zones.

Fixes: 40716b0bef06 ("ovn-tester: add the capability to deploy central components on multiple hv for ovn-ic")

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
