### PR TITLE
density_heavy: density_light: Fix startup stages when running in IC mode.

### DIFF
--- a/ovn-tester/cms/ovn_kubernetes/tests/density_light.py
+++ b/ovn-tester/cms/ovn_kubernetes/tests/density_light.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from ovn_context import Context
 from cms.ovn_kubernetes import Namespace
 from ovn_ext_cmd import ExtCmd
+from ovn_utils import distribute_n_tasks_per_clusters
 
 
 DensityCfg = namedtuple(
@@ -21,12 +22,16 @@ class DensityLight(ExtCmd):
 
     def run(self, clusters, global_cfg):
         ns = Namespace(clusters, 'ns_density_light', global_cfg)
+        n_startup_per_cluster = distribute_n_tasks_per_clusters(
+            self.config.n_startup, len(clusters)
+        )
+
         with Context(
             clusters, 'density_light_startup', len(clusters), brief_report=True
         ) as ctx:
             for i in ctx:
                 ports = clusters[i].provision_ports(
-                    self.config.n_startup, passive=True
+                    n_startup_per_cluster[i], passive=True
                 )
                 ns.add_ports(ports, i)
 

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -912,3 +912,8 @@ class OvnIcNbctl:
     def ts_add(self):
         log.info('Creating transit switch')
         self.uuid_transaction(partial(self.idl.ts_add, 'ts'))
+
+
+def distribute_n_tasks_per_clusters(n_tasks, n_clusters):
+    div, rest = divmod(n_tasks, n_clusters)
+    return [div + 1 if i < rest else div for i in range(n_clusters)]


### PR DESCRIPTION
In this mode we should actually distribute the ports that are created in the startup stage between AZs (clusters) instead of creating all of them in all AZs.

Fixes: 2562afb45721 ("ovn-tester: extend density_light testing for ovn-ic")
Fixes: 84649236d689 ("ovn-tester: extend density_heavy for ovn-ic")

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
