### PR TITLE
Fix default value for northd probe interval

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ low_scale_task:
       - image_project: fedora-cloud
         image: family/fedora-cloud-38
       - image_project: ubuntu-os-cloud
-        image: family/ubuntu-2310-amd64
+        image: family/ubuntu-2404-lts-amd64
     platform: linux
     memory: 8G
     disk: 40

--- a/ovn-fake-multinode-utils/translate_yaml.py
+++ b/ovn-fake-multinode-utils/translate_yaml.py
@@ -94,7 +94,7 @@ class ClusterConfig:
     log_txns_db: bool = False
     datapath_type: str = "system"
     raft_election_to: int = 16
-    northd_probe_interval: int = 5000
+    northd_probe_interval: int = 16000
     northd_threads: int = 4
     db_inactivity_probe: int = 60000
     node_net: str = "192.16.0.0/16"


### PR DESCRIPTION
Southbound DB cluster tolerates 16 seconds of leader being unavailable.  It doesn't make sense for northd to be more sensitive.  And also, at 500+ node scale it can take more than 5 seconds to send a full database snapshot leading to constant re-connections and 100% CPU usage on Sb DB server preparing the same snapshot over and over.

CI updated to Ubuntu 24.04, because 23.10 is EoL and images for it are no longer available on GCP.  However, CI will still fail until https://github.com/ovn-org/ovn-fake-multinode/pull/90 is merged.