### PR TITLE
.github: Bump checkout and setup-python versions to latest.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/ovn-tester/cms/openstack/tests/base_openstack.py
+++ b/ovn-tester/cms/openstack/tests/base_openstack.py
@@ -35,7 +35,7 @@ class BaseOpenstack(ExtCmd):
                     worker_node: ChassisNode = ovn.worker_nodes[i]
                     log.info(
                         f"Provisioning {worker_node.__class__.__name__} "
-                        f"({i+1}/{worker_count})"
+                        f"({i + 1}/{worker_count})"
                     )
                     worker_node.provision(ovn)
 

--- a/ovn-tester/cms/ovn_kubernetes/tests/base_cluster_bringup.py
+++ b/ovn-tester/cms/ovn_kubernetes/tests/base_cluster_bringup.py
@@ -82,10 +82,10 @@ class BaseClusterBringup(ExtCmd):
             with Context(
                 clusters, 'base_cluster_bringup', len(cluster.worker_nodes)
             ) as ctx:
-                cluster.create_cluster_router(f'lr-cluster{c+1}')
-                cluster.create_cluster_join_switch(f'ls-join{c+1}')
+                cluster.create_cluster_router(f'lr-cluster{c + 1}')
+                cluster.create_cluster_join_switch(f'ls-join{c + 1}')
                 cluster.create_cluster_load_balancer(
-                    f'lb-cluster{c+1}', global_cfg
+                    f'lb-cluster{c + 1}', global_cfg
                 )
                 self.connect_transit_switch(cluster)
                 for i in ctx:
@@ -96,7 +96,7 @@ class BaseClusterBringup(ExtCmd):
                     )
                     worker.provision_load_balancers(cluster, ports, global_cfg)
                     worker.ping_ports(cluster, ports)
-                cluster.provision_lb_group(f'cluster-lb-group{c+1}')
+                cluster.provision_lb_group(f'cluster-lb-group{c + 1}')
 
         # check ic connectivity
         self.check_ic_connectivity(clusters)

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -330,7 +330,7 @@ class Cluster:
         self.relay_nodes = [
             RelayNode(
                 central,
-                f'ovn-relay-az{self.az}-{i+1}',
+                f'ovn-relay-az{self.az}-{i + 1}',
                 mgmt_ip + i,
                 protocol,
             )


### PR DESCRIPTION
This removes python 3.7 from the lint jobs as this is not
supported anymore by the setup-python action.  It also adds the
newer versions supported by actions/setup-python@v5.

https://github.com/ovn-org/ovn-heater/actions/runs/13518101654/job/37770994792#step:3:7

While at it we bump the setup-python and checkout action versions
to the latest available (actions/checkout@v4 and
actions/setup-python@v5).

The new versions of flak8 report some additional style issues, those
are fixed by this commit too.