### PR TITLE
ovn_stats: Remove unused variable.

### DIFF
--- a/ovn-tester/ovn_stats.py
+++ b/ovn-tester/ovn_stats.py
@@ -29,7 +29,6 @@ def timeit(func):
 
 
 def clear():
-    global timed_functions
     timed_functions.clear()
 
 


### PR DESCRIPTION
Reported by flake8:
  ./ovn-tester/ovn_stats.py:32:5: F824 `global timed_functions` is
  unused: name is never assigned in scope

https://github.com/ovn-org/ovn-heater/actions/runs/18093736973/

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
