### PR TITLE
do.sh: Pin ovn-fake-multinode to v0.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ cd ~/ovn-heater
 ```
 
 This step will:
-- clone OVS, OVN and ovn-fake-multinode upstream main branches in the
+- clone OVS and OVN main branches in the `runtime` directory.
+- clone ovn-fake-multinode upstream latest stable tag (`v0.5`) in the
   `runtime` directory.
 - build the `ovn/ovn-multi-node` container image which will be used by the
   fake nodes spawned during the tests.  OVS/OVN binaries are built with

--- a/do.sh
+++ b/do.sh
@@ -119,7 +119,7 @@ ovn_branch="${OVN_BRANCH:-main}"
 
 # ovn-fake-multinode env vars
 ovn_fmn_repo="${OVN_FAKE_MULTINODE_REPO:-https://github.com/ovn-org/ovn-fake-multinode.git}"
-ovn_fmn_branch="${OVN_FAKE_MULTINODE_BRANCH:-main}"
+ovn_fmn_branch="${OVN_FAKE_MULTINODE_BRANCH:-v0.5}"
 
 OS_BASE="${OS_BASE:-fedora}"
 OS_IMAGE_OVERRIDE="${OS_IMAGE_OVERRIDE}"
@@ -295,8 +295,9 @@ function record_test_config() {
         pushd ${rundir}/$d
         local origin=$(git config --get remote.origin.url)
         local sha=$(git rev-parse HEAD)
-        local sha_name=$(git rev-parse --abbrev-ref HEAD)
-        echo "$d (${origin}): ${sha} (${sha_name})" >> ${out_file}
+        local name=$(git describe --tags --exact-match HEAD 2> /dev/null || \
+                     git rev-parse --abbrev-ref HEAD)
+        echo "$d (${origin}): ${sha} (${name})" >> ${out_file}
         popd
     done
 }


### PR DESCRIPTION
This is currently the latest stable tag ovn-fake-multinode provides and is tested to work with ovn-heater.  Like this we avoid unexpected breakages due to ovn-fake-multinode changes on the main branch.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
