### PR TITLE
do.sh: Fix how clone_component() detects new branches/tags.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -85,14 +85,12 @@ function clone_component() {
         pushd ${comp_name}
         local remote=$(git config --get remote.origin.url)
         if [ "${remote}" = "${comp_repo}" ]; then
-            git fetch origin
+            git fetch --tags origin
 
-            if $(git show-ref --verify refs/tags/${comp_branch} &> /dev/null); then
-                local branch_diff=$(git diff ${comp_branch} HEAD --stat | wc -l)
-            else
-                local branch_diff=$(git diff origin/${comp_branch} HEAD --stat | wc -l)
-            fi
-            if [ "${branch_diff}" = "0" ]; then
+            if $(git show-ref --verify refs/tags/${comp_branch} &> /dev/null) \
+                    && $(git diff ${comp_branch} HEAD --quiet &> /dev/null); then
+                comp_exists="1"
+            elif $(git diff origin/${comp_branch} HEAD --quiet &> /dev/null); then
                 comp_exists="1"
             fi
         fi


### PR DESCRIPTION
The function didn't use to fetch tags from the origin repo and also the way it diff-ed the local code to the remote one was incorrect.  That's because:

  git diff <..> --stat | wc -l

always sets the return code to 0 (that of wc).

Instead of that, just use the more robust way of doing things

  git diff --quiet <..>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-heater/blob/main/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"
-->
